### PR TITLE
fix and use ephemeral port from platform

### DIFF
--- a/java/client/src/org/openqa/selenium/net/LinuxEphemeralPortRangeDetector.java
+++ b/java/client/src/org/openqa/selenium/net/LinuxEphemeralPortRangeDetector.java
@@ -46,9 +46,9 @@ public class LinuxEphemeralPortRangeDetector implements EphemeralPortRangeDetect
     int lowPort = defaultRange.getLowestEphemeralPort();
     int highPort = defaultRange.getHighestEphemeralPort();
     try (BufferedReader in = new BufferedReader(inputFil)) {
-      String[] split = in.readLine().split("\\s");
+      String[] split = in.readLine().split("\\s", 2);
       lowPort = Integer.parseInt(split[0]);
-      highPort = Integer.parseInt(split[1]);
+      highPort = Integer.parseInt(split[1].trim());
     } catch (IOException ignore) {
     }
     firstEphemeralPort = lowPort;

--- a/java/client/src/org/openqa/selenium/net/PortProber.java
+++ b/java/client/src/org/openqa/selenium/net/PortProber.java
@@ -17,7 +17,6 @@
 
 package org.openqa.selenium.net;
 
-import static java.lang.Math.max;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import org.openqa.selenium.Platform;
@@ -79,20 +78,9 @@ public class PortProber {
    */
   private static int createAcceptablePort() {
     synchronized (random) {
-      final int FIRST_PORT;
-      final int LAST_PORT;
-
-      int freeAbove = HIGHEST_PORT - ephemeralRangeDetector.getHighestEphemeralPort();
-      int freeBelow = max(0, ephemeralRangeDetector.getLowestEphemeralPort() - START_OF_USER_PORTS);
-
-      if (freeAbove > freeBelow) {
-        FIRST_PORT = ephemeralRangeDetector.getHighestEphemeralPort();
-        LAST_PORT = 65535;
-      } else {
-        FIRST_PORT = 1024;
-        LAST_PORT = ephemeralRangeDetector.getLowestEphemeralPort();
-      }
-
+      final int FIRST_PORT = Math.max(START_OF_USER_PORTS, ephemeralRangeDetector.getLowestEphemeralPort());
+      final int LAST_PORT = Math.min(HIGHEST_PORT, ephemeralRangeDetector.getHighestEphemeralPort());
+      
       if (FIRST_PORT == LAST_PORT) {
         return FIRST_PORT;
       }


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/selenium/blob/master/CONTRIBUTING.md#step-6-sign-the-cla)

This solves the port negotiation problem on linux (and maybe other platforms). #1630 

The removed code leads to the result that `FIRST_PORT` and `LAST_PORT` is both set to 1024 which always returns 1024. In fact we should trust the ephemeral ports reports by the detector. With the min and max we just assure a valid port range.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/seleniumhq/selenium/6704)
<!-- Reviewable:end -->
